### PR TITLE
implement feature level sorting for result display

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,46 @@ gender_results = results.features["gender"].to_dataframe()
 male_results = results.features["gender"].levels["Male"].to_dataframe()
 ```
 
+## Controlling Feature Level Order
+
+By default, feature levels appear in the order they were encountered in the
+data.  To control the row order in exported DataFrames, assign the feature
+column a `pd.Categorical` dtype with an explicit `categories` list before
+passing the data to the auditor:
+
+```python
+import pandas as pd
+from model_auditor import Auditor
+from model_auditor.metrics import Sensitivity, Specificity
+
+# Declare the desired display order for the 'age_group' column.
+# Categories not present in the data still appear as rows (with NaN values).
+df["age_group"] = pd.Categorical(
+    df["age_group"],
+    categories=["<30", "30-50", "50-70", ">70"],
+    ordered=True,
+)
+
+auditor = Auditor()
+auditor.add_data(df)
+auditor.add_feature(name="age_group")
+auditor.add_score(name="risk_score", threshold=0.5)
+auditor.add_outcome(name="outcome")
+auditor.set_metrics([Sensitivity(), Specificity()])
+
+results = auditor.evaluate(score_name="risk_score", n_bootstraps=None)
+
+# Rows appear in the declared order: <30, 30-50, 50-70, >70.
+# If no rows belong to a declared category (e.g. '>70' is absent from the
+# data), that category still appears as a row with NaN metric values.
+df_out = results.features["age_group"].to_dataframe()
+```
+
+The same order is preserved in `style_dataframe()` and in the score-level
+`ScoreEvaluation.to_dataframe()` / `ScoreEvaluation.style_dataframe()` exports.
+Non-categorical feature columns are unaffected.
+
+
 ## License
 ## Notebook Styling
 

--- a/model_auditor/core.py
+++ b/model_auditor/core.py
@@ -20,6 +20,7 @@ from model_auditor.schemas import (
     AuditorScore,
     AuditorOutcome,
     FeatureEvaluation,
+    LevelEvaluation,
     ScoreEvaluation,
 )
 from model_auditor.utils import collect_metric_inputs
@@ -347,6 +348,11 @@ class Auditor:
     ) -> FeatureEvaluation:
         """Evaluate all metrics for a single feature across its levels.
 
+        When the feature column carries a categorical dtype, levels are ordered
+        according to the declared category order.  Categories present in the
+        declaration but absent in the data appear as placeholder rows whose
+        metric scores are NaN.
+
         Args:
             data: DataFrame containing the evaluation data with metric input columns.
             feature: The feature to stratify evaluation by.
@@ -355,12 +361,31 @@ class Auditor:
         Returns:
             FeatureEvaluation containing metrics for each level of the feature.
         """
-        # Drop rows where the feature value is NaN (they don't belong to any subgroup)
-        feature_data = data.dropna(subset=[feature.name]).copy()
-        feature_data[feature.name] = feature_data[feature.name].astype(str)
-        feature_groups = feature_data.groupby(feature.name)
+        feature_col = feature.name
 
-        # e.g. {"f1": {'levelA': 0.2, 'levelB': 0.4}, ... }
+        # Detect categorical dtype *before* any transformation so we capture the
+        # user-declared category order.  dropna preserves the dtype, but astype(str)
+        # would destroy it.
+        is_categorical = isinstance(data[feature_col].dtype, pd.CategoricalDtype)
+        declared_categories: list[str] = []
+        if is_categorical:
+            declared_categories = [
+                str(c) for c in data[feature_col].cat.categories.tolist()
+            ]
+
+        # Drop rows where the feature value is NaN; they don't belong to any level.
+        feature_data = data.dropna(subset=[feature_col]).copy()
+
+        if is_categorical:
+            # Keep the categorical dtype so the groupby key type is consistent.
+            # observed=True restricts grouping to categories that actually appear in
+            # this slice; unobserved categories are handled as placeholders below.
+            feature_groups = feature_data.groupby(feature_col, observed=True)
+        else:
+            # Non-categorical path: coerce to string (existing behaviour).
+            feature_data[feature_col] = feature_data[feature_col].astype(str)
+            feature_groups = feature_data.groupby(feature_col)
+
         feature_eval: FeatureEvaluation = FeatureEvaluation(
             name=feature.name,
             label=feature.label if feature.label is not None else feature.name,
@@ -369,6 +394,9 @@ class Auditor:
             # gets a dict with the current metric calculated for levels of the feature
             # e.g. {levelA: 0.5, levelB: 0.5}
             level_eval_dict = feature_groups.apply(metric.data_call).to_dict()
+            # Normalise keys to strings; categorical keys are the category values,
+            # which may already be strings but we guarantee it here.
+            level_eval_dict = {str(k): v for k, v in level_eval_dict.items()}
 
             feature_eval.update(
                 metric_name=metric.name,
@@ -390,6 +418,26 @@ class Auditor:
                     level_name=str(level_name),
                     metric_intervals=level_metric_intervals,
                 )
+
+        if is_categorical:
+            # Rebuild levels dict in declared category order.  For each declared
+            # category: use the computed LevelEvaluation if the category was
+            # observed, otherwise insert a placeholder with NaN metric scores so
+            # that to_dataframe() / style_dataframe() produce a complete row.
+            ordered_levels: dict[str, LevelEvaluation] = {}
+            for cat_str in declared_categories:
+                if cat_str in feature_eval.levels:
+                    ordered_levels[cat_str] = feature_eval.levels[cat_str]
+                else:
+                    placeholder = LevelEvaluation(name=cat_str)
+                    for metric in self.metrics:
+                        placeholder.update(
+                            metric_name=metric.name,
+                            metric_label=metric.label,
+                            metric_score=float("nan"),
+                        )
+                    ordered_levels[cat_str] = placeholder
+            feature_eval.levels = ordered_levels
 
         return feature_eval
 

--- a/tests/test_feature_level_ordering.py
+++ b/tests/test_feature_level_ordering.py
@@ -1,0 +1,310 @@
+"""Tests for feature-level ordering in DataFrame exports.
+
+Coverage:
+- Categorical feature columns produce rows in declared category order.
+- Unobserved categories appear as placeholder rows with NaN metric scores.
+- Non-categorical features retain existing (insertion-order) behaviour.
+- Both to_dataframe() and style_dataframe() honour the category order.
+- ScoreEvaluation-level exports inherit the same feature-level order.
+- Bootstrap CI computation is unaffected (observed groups only; placeholders
+  keep None intervals).
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from model_auditor import Auditor
+from model_auditor.metrics import Sensitivity, Specificity, nData
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CATEGORIES = ["C", "B", "A", "D"]  # custom non-alphabetical order; 'D' unobserved by default
+
+
+def _make_df(include_d: bool = False) -> pd.DataFrame:
+    """Return a synthetic binary-classification DataFrame.
+
+    Groups A, B, C are always present.  Group D is included only when
+    include_d=True.  The 'group' column is categorical with declared order
+    ['C', 'B', 'A', 'D'].
+    """
+    rows = []
+    for grp, n_pos, n_neg in [("A", 3, 2), ("B", 2, 3), ("C", 4, 1)]:
+        rows += [{"group": grp, "score": 0.8, "label": 1}] * n_pos
+        rows += [{"group": grp, "score": 0.2, "label": 0}] * n_neg
+    if include_d:
+        rows += [{"group": "D", "score": 0.8, "label": 1}] * 2
+        rows += [{"group": "D", "score": 0.2, "label": 0}] * 2
+
+    df = pd.DataFrame(rows)
+    df["group"] = pd.Categorical(df["group"], categories=CATEGORIES, ordered=True)
+    return df
+
+
+def _make_auditor(df: pd.DataFrame, metrics=None) -> Auditor:
+    if metrics is None:
+        metrics = [Sensitivity(), nData()]
+    auditor = Auditor()
+    auditor.add_data(df)
+    auditor.add_feature(name="group")
+    auditor.add_score(name="score", threshold=0.5)
+    auditor.add_outcome(name="label")
+    auditor.set_metrics(metrics)
+    return auditor
+
+
+def _evaluate(include_d: bool = False, n_bootstraps=None, metrics=None):
+    df = _make_df(include_d=include_d)
+    return _make_auditor(df, metrics=metrics).evaluate(
+        score_name="score", n_bootstraps=n_bootstraps
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestCategoricalLevelOrder — ordering and placeholders (primary feature)
+# ---------------------------------------------------------------------------
+
+
+class TestCategoricalLevelOrder:
+    """Categorical feature columns follow declared category order in all exports."""
+
+    # -- levels dict order ---------------------------------------------------
+
+    def test_levels_dict_order_matches_declared_categories(self):
+        """FeatureEvaluation.levels preserves declared categorical order."""
+        results = _evaluate()
+        keys = list(results.features["group"].levels.keys())
+        assert keys == CATEGORIES, f"Expected {CATEGORIES}, got {keys}"
+
+    # -- to_dataframe order --------------------------------------------------
+
+    def test_feature_to_dataframe_row_order(self):
+        """FeatureEvaluation.to_dataframe() index follows declared category order."""
+        results = _evaluate()
+        df = results.features["group"].to_dataframe()
+        assert list(df.index) == CATEGORIES, (
+            f"Expected {CATEGORIES}, got {list(df.index)}"
+        )
+
+    def test_score_to_dataframe_group_row_order(self):
+        """ScoreEvaluation.to_dataframe() group rows follow declared category order."""
+        results = _evaluate()
+        df = results.to_dataframe()
+        # MultiIndex: level 0 = feature label, level 1 = level name
+        group_df = df.loc["group"]
+        assert list(group_df.index) == CATEGORIES, (
+            f"Expected {CATEGORIES}, got {list(group_df.index)}"
+        )
+
+    # -- style_dataframe order -----------------------------------------------
+
+    def test_feature_style_dataframe_row_order(self):
+        """FeatureEvaluation.style_dataframe() Styler.data index follows category order."""
+        results = _evaluate()
+        styler = results.features["group"].style_dataframe()
+        assert list(styler.data.index) == CATEGORIES, (
+            f"Expected {CATEGORIES}, got {list(styler.data.index)}"
+        )
+
+    def test_score_style_dataframe_group_row_order(self):
+        """ScoreEvaluation.style_dataframe() group rows follow declared category order."""
+        results = _evaluate()
+        styler = results.style_dataframe()
+        group_rows = styler.data.loc["group"]
+        assert list(group_rows.index) == CATEGORIES, (
+            f"Expected {CATEGORIES}, got {list(group_rows.index)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestUnobservedCategoryPlaceholders
+# ---------------------------------------------------------------------------
+
+
+class TestUnobservedCategoryPlaceholders:
+    """Categories declared but absent in data appear as NaN rows."""
+
+    def test_unobserved_category_row_exists(self):
+        """Row for 'D' (unobserved) is present in to_dataframe() output."""
+        results = _evaluate()
+        df = results.features["group"].to_dataframe()
+        assert "D" in df.index, "Missing row for unobserved category 'D'"
+
+    def test_unobserved_category_raw_metrics_are_nan(self):
+        """LevelEvaluation for unobserved 'D' has NaN scores for every metric."""
+        results = _evaluate()
+        level_d = results.features["group"].levels["D"]
+        assert len(level_d.metrics) > 0, (
+            "Placeholder level 'D' must have metric entries (not an empty dict)"
+        )
+        for name, lm in level_d.metrics.items():
+            assert math.isnan(lm.score), (
+                f"Metric '{name}' for unobserved 'D' must be NaN, got {lm.score}"
+            )
+
+    def test_unobserved_category_no_confidence_interval(self):
+        """Placeholder level for 'D' must not carry a confidence interval."""
+        results = _evaluate()
+        level_d = results.features["group"].levels["D"]
+        for name, lm in level_d.metrics.items():
+            assert lm.interval is None, (
+                f"Metric '{name}' for unobserved 'D' should have no CI, got {lm.interval}"
+            )
+
+    def test_unobserved_category_row_in_score_dataframe(self):
+        """Row for 'D' appears in ScoreEvaluation.to_dataframe() under 'group'."""
+        results = _evaluate()
+        df = results.to_dataframe()
+        group_df = df.loc["group"]
+        assert "D" in group_df.index
+
+    def test_observed_categories_are_not_nan(self):
+        """Observed categories A, B, C have finite (non-NaN) metric scores."""
+        results = _evaluate()
+        feature = results.features["group"]
+        for cat in ("A", "B", "C"):
+            level = feature.levels[cat]
+            for name, lm in level.metrics.items():
+                assert not math.isnan(lm.score), (
+                    f"Metric '{name}' for observed '{cat}' should be finite, got {lm.score}"
+                )
+
+    def test_placeholder_metric_set_matches_observed_levels(self):
+        """Placeholder 'D' has the same set of metric names as an observed level."""
+        results = _evaluate()
+        feature = results.features["group"]
+        observed_metric_names = set(feature.levels["A"].metrics.keys())
+        placeholder_metric_names = set(feature.levels["D"].metrics.keys())
+        assert placeholder_metric_names == observed_metric_names, (
+            f"Placeholder metric names {placeholder_metric_names} != observed {observed_metric_names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestAllCategoriesObserved
+# ---------------------------------------------------------------------------
+
+
+class TestAllCategoriesObserved:
+    """When every declared category has rows, ordering still follows declaration."""
+
+    def test_all_observed_level_order(self):
+        results = _evaluate(include_d=True)
+        keys = list(results.features["group"].levels.keys())
+        assert keys == CATEGORIES
+
+    def test_no_nan_scores_when_all_observed(self):
+        results = _evaluate(include_d=True)
+        feature = results.features["group"]
+        for cat in CATEGORIES:
+            for name, lm in feature.levels[cat].metrics.items():
+                assert not math.isnan(lm.score), (
+                    f"Metric '{name}' for observed '{cat}' should not be NaN"
+                )
+
+
+# ---------------------------------------------------------------------------
+# TestBootstrapCIWithCategorical
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapCIWithCategorical:
+    """CI computation runs only on observed groups; placeholders stay CI-free."""
+
+    def test_observed_groups_get_ci_for_eligible_metrics(self):
+        """Observed levels receive confidence intervals for ci_eligible metrics."""
+        results = _evaluate(n_bootstraps=50)
+        feature = results.features["group"]
+        for cat in ("A", "B", "C"):
+            sensitivity_metric = feature.levels[cat].metrics.get("sensitivity")
+            assert sensitivity_metric is not None
+            assert sensitivity_metric.interval is not None, (
+                f"Observed '{cat}' should have a CI for Sensitivity"
+            )
+
+    def test_unobserved_placeholder_has_no_ci(self):
+        """The NaN placeholder for 'D' carries no CI even when bootstraps are run."""
+        results = _evaluate(n_bootstraps=50)
+        level_d = results.features["group"].levels["D"]
+        for name, lm in level_d.metrics.items():
+            assert lm.interval is None, (
+                f"Placeholder '{name}' for unobserved 'D' must not have a CI"
+            )
+
+    def test_count_metric_has_no_ci(self):
+        """nData (ci_eligible=False) has no interval for any observed level."""
+        results = _evaluate(n_bootstraps=50)
+        feature = results.features["group"]
+        for cat in ("A", "B", "C"):
+            n_metric = feature.levels[cat].metrics.get("n")
+            assert n_metric is not None
+            assert n_metric.interval is None, (
+                f"nData should never carry a CI, got {n_metric.interval}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestNonCategoricalPreservation
+# ---------------------------------------------------------------------------
+
+
+class TestNonCategoricalPreservation:
+    """Non-categorical feature columns retain existing string-based behaviour."""
+
+    def _results_string_feature(self):
+        df = _make_df()
+        # Strip categorical dtype → plain object/string column
+        df["group"] = df["group"].astype(str)
+        return _make_auditor(df).evaluate(score_name="score", n_bootstraps=None)
+
+    def test_non_categorical_evaluates_without_error(self):
+        """String-typed feature evaluates successfully."""
+        results = self._results_string_feature()
+        assert "group" in results.features
+
+    def test_non_categorical_no_unobserved_placeholders(self):
+        """No phantom row for 'D' when the feature is not categorical."""
+        results = self._results_string_feature()
+        assert "D" not in results.features["group"].levels, (
+            "Non-categorical feature must not generate phantom 'D' row"
+        )
+
+    def test_non_categorical_observed_levels_only(self):
+        """Only A, B, C appear as levels for the non-categorical feature."""
+        results = self._results_string_feature()
+        assert set(results.features["group"].levels.keys()) == {"A", "B", "C"}
+
+    def test_non_categorical_metrics_are_finite(self):
+        """All metrics for observed non-categorical levels are finite."""
+        results = self._results_string_feature()
+        for cat in ("A", "B", "C"):
+            for name, lm in results.features["group"].levels[cat].metrics.items():
+                assert not math.isnan(lm.score), (
+                    f"Non-categorical metric '{name}' for '{cat}' must be finite"
+                )
+
+
+# ---------------------------------------------------------------------------
+# TestMultipleMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleMetrics:
+    """Ordering and placeholders work across a richer metric set."""
+
+    def test_multiple_metrics_preserve_category_order(self):
+        """All metrics populate in category order; placeholders cover every metric."""
+        results = _evaluate(metrics=[Sensitivity(), Specificity(), nData()])
+        keys = list(results.features["group"].levels.keys())
+        assert keys == CATEGORIES
+
+        # Placeholder 'D' has one entry per declared metric
+        metric_names = {"sensitivity", "specificity", "n"}
+        placeholder_names = set(results.features["group"].levels["D"].metrics.keys())
+        assert placeholder_names == metric_names


### PR DESCRIPTION
### **Feature: User-controlled feature level ordering via pd.Categorical**

### What changed

Auditor._evaluate_feature now detects whether a stratification feature column carries a pd.CategoricalDtype. When it does:

- Levels in all exports (to_dataframe, style_dataframe, and their ScoreEvaluation-level counterparts) follow the declared category order
 rather than data-encounter order.
- Categories declared but absent from the evaluated data appear as explicit rows with NaN metric scores and no confidence intervals, so
 exports always cover the full declared category set.
- Bootstrap CI computation is unaffected; only observed groups are resampled.

Non-categorical features retain all existing behaviour.

**User-facing API change**: none. Control ordering by assigning a categorical dtype before calling add_data:

```python
df["age_group"] = pd.Categorical(
    df["age_group"],
    categories=["<30", "30-50", "50-70", ">70"],
    ordered=True,
)
```

### Files changed
- model_auditor/core.py — categorical-aware _evaluate_feature; imports LevelEvaluation
- tests/test_feature_level_ordering.py — 21 new tests across 6 classes
- README.md — new "Controlling Feature Level Order" section

Tests: 21 new + 42 existing, all passing