### PR TITLE
feature: Added error evaluation and confusion matrix group analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ class AuditorMetricInput(Protocol):
 
 ### Accessing Results
 ```python
-results = auditor.evaluate(score_name="risk_score")
+results = auditor.evaluate_metrics(score_name="risk_score")
 df = results.to_dataframe(n_decimals=3, metric_labels=True)
 feature_df = results.features["gender"].to_dataframe()
 level_df = results.features["gender"].levels["Male"].to_dataframe()

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ auditor.set_metrics([
 ])
 
 # Run evaluation with bootstrap confidence intervals
-results = auditor.evaluate(score_name="risk_score", n_bootstraps=1000)
+results = auditor.evaluate_metrics(score_name="risk_score", n_bootstraps=1000)
 
 # Convert results to a DataFrame
 results_df = results.to_dataframe()
@@ -196,7 +196,7 @@ plotter.set_features(hierarchy)
 For faster evaluation without confidence intervals:
 
 ```python
-results = auditor.evaluate(score_name="risk_score", n_bootstraps=None)
+results = auditor.evaluate_metrics(score_name="risk_score", n_bootstraps=None)
 ```
 
 ## Output Format
@@ -241,7 +241,7 @@ auditor.add_score(name="risk_score", threshold=0.5)
 auditor.add_outcome(name="outcome")
 auditor.set_metrics([Sensitivity(), Specificity()])
 
-results = auditor.evaluate(score_name="risk_score", n_bootstraps=None)
+results = auditor.evaluate_metrics(score_name="risk_score", n_bootstraps=None)
 
 # Rows appear in the declared order: <30, 30-50, 50-70, >70.
 # If no rows belong to a declared category (e.g. '>70' is absent from the
@@ -253,6 +253,35 @@ The same order is preserved in `style_dataframe()` and in the score-level
 `ScoreEvaluation.to_dataframe()` / `ScoreEvaluation.style_dataframe()` exports.
 Non-categorical feature columns are unaffected.
 
+
+
+## Error Analysis
+
+Use `evaluate_errors()` to understand which subgroups are over- or
+under-represented within each confusion-matrix group (TP, TN, FP, FN).
+For every feature level the *representation ratio* is computed:
+
+    ratio = P(level | group) / P(level | full dataset)
+
+A ratio of 1.0 means proportional representation.  Values above 1.0 indicate
+over-representation in that confusion group; below 1.0 under-representation.
+
+```python
+# No additional metric setup required — evaluate_errors() uses RepresentationRatio
+# by default.
+error_results = auditor.evaluate_errors(score_name="risk_score", n_bootstraps=1000)
+
+# error_results.groups is keyed by 'tp', 'tn', 'fp', 'fn'.
+# Each value is a ScoreEvaluation containing per-feature representation ratios.
+
+# Convert to a (group, feature, level) MultiIndex DataFrame:
+df = error_results.to_dataframe()
+print(df)
+
+# Inspect a specific group/feature:
+tp_age = error_results.groups["tp"].features["age_group"]
+print(tp_age.to_dataframe())
+```
 
 ## License
 ## Notebook Styling

--- a/example.ipynb
+++ b/example.ipynb
@@ -160,7 +160,7 @@
    "source": [
     "# Run evaluation with bootstrap confidence intervals\n",
     "# Using 500 bootstraps for faster execution (use 1000+ for production)\n",
-    "results = auditor.evaluate(score_name='risk_score', n_bootstraps=500)"
+    "results = auditor.evaluate_metrics(score_name='risk_score', n_bootstraps=500)"
    ]
   },
   {
@@ -274,7 +274,7 @@
    "outputs": [],
    "source": [
     "# Re-evaluate with optimal threshold\n",
-    "results_optimal = auditor.evaluate(\n",
+    "results_optimal = auditor.evaluate_metrics(\n",
     "    score_name='risk_score', \n",
     "    threshold=optimal_threshold,\n",
     "    n_bootstraps=500\n",
@@ -302,7 +302,7 @@
    "outputs": [],
    "source": [
     "# Fast evaluation without CIs\n",
-    "results_fast = auditor.evaluate(score_name='risk_score', n_bootstraps=None)\n",
+    "results_fast = auditor.evaluate_metrics(score_name='risk_score', n_bootstraps=None)\n",
     "results_fast.to_dataframe(n_decimals=3, metric_labels=True)"
    ]
   },
@@ -374,7 +374,7 @@
     "    MatthewsCorrelationCoefficient(),\n",
     "])\n",
     "\n",
-    "results_custom = auditor.evaluate(score_name='risk_score', n_bootstraps=500)\n",
+    "results_custom = auditor.evaluate_metrics(score_name='risk_score', n_bootstraps=500)\n",
     "results_custom.features['age_group'].to_dataframe(n_decimals=3, metric_labels=True)"
    ]
   },
@@ -405,7 +405,7 @@
     "    FBetaScore(beta=2.0),   # Weights recall higher\n",
     "])\n",
     "\n",
-    "results_fbeta = auditor.evaluate(score_name='risk_score', n_bootstraps=None)\n",
+    "results_fbeta = auditor.evaluate_metrics(score_name='risk_score', n_bootstraps=None)\n",
     "results_fbeta.features['overall'].to_dataframe(n_decimals=3, metric_labels=True)"
    ]
   },
@@ -578,7 +578,7 @@
     "])\n",
     "\n",
     "# 4. Evaluate with confidence intervals\n",
-    "results = auditor.evaluate(\n",
+    "results = auditor.evaluate_metrics(\n",
     "    score_name='risk_score',\n",
     "    threshold=threshold,\n",
     "    n_bootstraps=500\n",
@@ -605,6 +605,46 @@
     "print(\"PERFORMANCE BY GENDER\")\n",
     "print(\"-\"*60)\n",
     "display(results.features['gender'].to_dataframe(n_decimals=3, metric_labels=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Error Analysis: Representation Ratios\n",
+    "\n",
+    "`evaluate_errors()` reveals which subgroups are over- or under-represented in each confusion-matrix group (TP, TN, FP, FN). For each feature level the **representation ratio** is computed:\n",
+    "\n",
+    "    ratio = P(level | group) / P(level | full dataset)\n",
+    "\n",
+    "A ratio of 1.0 means proportional representation. Values above 1.0 indicate over-representation in that confusion group; below 1.0 indicates under-representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Error analysis: representation ratios per confusion group\n",
+    "# n_bootstraps=200 for demonstration; use 1000+ in production\n",
+    "error_results = auditor.evaluate_errors(score_name='risk_score', n_bootstraps=200)\n",
+    "\n",
+    "# Full results as a (group, feature, level) MultiIndex DataFrame\n",
+    "error_df = error_results.to_dataframe(n_decimals=3, metric_labels=True)\n",
+    "display(error_df)\n",
+    "\n",
+    "# Inspect false-positive representation by age group\n",
+    "print(\"\\nFalse Positives \u2014 representation ratio by age group:\")\n",
+    "display(\n",
+    "    error_results.groups['fp'].features['age_group'].to_dataframe(\n",
+    "        n_decimals=3, metric_labels=True\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Styled view for the TP group across all features\n",
+    "print(\"\\nTrue Positives \u2014 styled representation ratios:\")\n",
+    "display(error_results.groups['tp'].style_dataframe(metric_labels=True))"
    ]
   },
   {

--- a/model_auditor/__init__.py
+++ b/model_auditor/__init__.py
@@ -16,7 +16,7 @@ Example:
         auditor.add_score(name="prediction_score", threshold=0.5)
         auditor.add_outcome(name="label")
         auditor.set_metrics([Sensitivity(), Specificity(), AUROC()])
-        results = auditor.evaluate(score_name="prediction_score")
+        results = auditor.evaluate_metrics(score_name="prediction_score")
 """
 
 from model_auditor.core import Auditor

--- a/model_auditor/core.py
+++ b/model_auditor/core.py
@@ -13,12 +13,14 @@ from numpy.typing import NDArray
 from sklearn.metrics import roc_curve
 from tqdm.auto import tqdm
 
+from model_auditor.error_metrics import AuditorErrorMetric, RepresentationRatio
 from model_auditor.metric_inputs import AuditorMetricInput
 from model_auditor.metrics import AuditorMetric
 from model_auditor.schemas import (
     AuditorFeature,
     AuditorScore,
     AuditorOutcome,
+    ErrorEvaluation,
     FeatureEvaluation,
     LevelEvaluation,
     ScoreEvaluation,
@@ -46,7 +48,7 @@ class Auditor:
         >>> auditor.add_score(name="risk_score", threshold=0.5)
         >>> auditor.add_outcome(name="outcome")
         >>> auditor.set_metrics([Sensitivity(), Specificity()])
-        >>> results = auditor.evaluate(score_name="risk_score")
+        >>> results = auditor.evaluate_metrics(score_name="risk_score")
     """
 
     def __init__(
@@ -207,6 +209,34 @@ class Auditor:
         """
         self.metrics: list[AuditorMetric] = metrics
 
+    # ------------------------------------------------------------------ #
+    # Private helpers                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _resolve_threshold(
+        self, score: AuditorScore, threshold: Optional[float]
+    ) -> float:
+        """Resolve the effective threshold for a score.
+
+        Args:
+            score: The AuditorScore containing the optional default threshold.
+            threshold: Override value from the caller; None to use the score default.
+
+        Returns:
+            The resolved threshold value.
+
+        Raises:
+            ValueError: If both the caller argument and the score default are None.
+        """
+        if threshold is not None:
+            return threshold
+        if score.threshold is not None:
+            return score.threshold
+        raise ValueError(
+            f"Threshold for score '{score.name}' must be defined via "
+            "add_score(threshold=...) or passed to the evaluation method."
+        )
+
     def _collect_inputs(self) -> None:
         """
         Collects the minimum set of metric inputs necessary for evaluation
@@ -253,7 +283,28 @@ class Auditor:
         """
         return (score_data >= threshold).astype(int)
 
-    def evaluate(
+    def _add_confusion_columns(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Add tp/tn/fp/fn indicator columns to a DataFrame in-place.
+
+        Requires '_truth' and '_binary_pred' columns to already be present.
+
+        Args:
+            data: DataFrame to augment.
+
+        Returns:
+            The same DataFrame with tp, tn, fp, fn integer columns added.
+        """
+        data["tp"] = ((data["_truth"] == 1.0) & (data["_binary_pred"] == 1.0)).astype(int)
+        data["tn"] = ((data["_truth"] == 0.0) & (data["_binary_pred"] == 0.0)).astype(int)
+        data["fp"] = ((data["_truth"] == 0.0) & (data["_binary_pred"] == 1.0)).astype(int)
+        data["fn"] = ((data["_truth"] == 1.0) & (data["_binary_pred"] == 0.0)).astype(int)
+        return data
+
+    # ------------------------------------------------------------------ #
+    # Public evaluation methods                                            #
+    # ------------------------------------------------------------------ #
+
+    def evaluate_metrics(
         self,
         score_name: str,
         threshold: Optional[float] = None,
@@ -276,11 +327,18 @@ class Auditor:
 
         Raises:
             ValueError: If no data has been added with .add_data() first.
+            ValueError: If no outcome has been defined with .add_outcome() first.
             ValueError: If no metrics have been defined with .set_metrics() first.
+            ValueError: If score_name is not found in the registered scores.
             ValueError: If threshold is None and not defined in the score object.
         """
         if self.data is None:
             raise ValueError("Please add data with .add_data() first")
+
+        if "_truth" not in self.data.columns:
+            raise ValueError(
+                "Please define an outcome variable with .add_outcome() first"
+            )
 
         if len(self.metrics) == 0:
             raise ValueError(
@@ -295,13 +353,7 @@ class Auditor:
             )
 
         score: AuditorScore = self.scores[score_name]
-
-        if threshold is None and score.threshold is None:
-            raise ValueError(
-                "Threshold must be defined in score object or passed to .evaluate_score()"
-            )
-        elif threshold is None:
-            threshold = score.threshold
+        threshold = self._resolve_threshold(score, threshold)
 
         # collect metric inputs to prep for evaluation
         self._collect_inputs()
@@ -342,6 +394,108 @@ class Auditor:
                 score_eval.features[feature.name] = feature_eval
 
         return score_eval
+
+    def evaluate_errors(
+        self,
+        score_name: str,
+        threshold: Optional[float] = None,
+        n_bootstraps: Optional[int] = 1000,
+    ) -> ErrorEvaluation:
+        """Analyse feature-level representation within each confusion-matrix group.
+
+        For each confusion-matrix group (TP, TN, FP, FN) and each registered
+        feature, computes the representation ratio of every feature level:
+
+            ratio = P(level | group) / P(level | full dataset)
+
+        A ratio of 1.0 indicates a level appears proportionally in the group.
+        Values above 1.0 indicate over-representation; below 1.0 under-
+        representation.
+
+        With bootstrap resampling enabled (n_bootstraps is not None), the stored
+        point estimate is the bootstrap mean ratio and the confidence interval
+        spans the 2.5th–97.5th percentiles of the bootstrap distribution.
+
+        Args:
+            score_name: Name of the score column to evaluate.
+            threshold: Decision threshold for binarizing scores. If None, uses
+                the threshold defined in the AuditorScore object.
+            n_bootstraps: Number of bootstrap samples for confidence intervals.
+                Set to None to disable CI calculation.
+
+        Returns:
+            ErrorEvaluation containing one ScoreEvaluation per confusion group.
+
+        Raises:
+            ValueError: If no data has been added with .add_data() first.
+            ValueError: If no outcome has been defined with .add_outcome() first.
+            ValueError: If score_name is not found in the registered scores.
+            ValueError: If threshold is None and not defined in the score object.
+        """
+        if self.data is None:
+            raise ValueError("Please add data with .add_data() first")
+
+        if "_truth" not in self.data.columns:
+            raise ValueError(
+                "Please define an outcome variable with .add_outcome() first"
+            )
+
+        if score_name not in self.scores:
+            available = ", ".join(self.scores.keys()) or "(none)"
+            raise ValueError(
+                f"Score '{score_name}' not found. Available scores: {available}"
+            )
+
+        score: AuditorScore = self.scores[score_name]
+        threshold = self._resolve_threshold(score, threshold)
+
+        # Build the analysis slice: feature columns + truth + binarised predictions
+        # + all four confusion-matrix indicator columns.
+        column_list: list[str] = [*self.features.keys(), "_truth"]
+        data_slice: pd.DataFrame = self.data.loc[:, column_list].copy()  # type: ignore
+        data_slice["_pred"] = self.data[score.name]
+        data_slice["_binary_pred"] = self._binarize(
+            score_data=data_slice["_pred"], threshold=threshold
+        )
+        self._add_confusion_columns(data_slice)
+
+        # Synthetic 'Overall' feature (same pattern as evaluate_metrics).
+        data_slice["overall"] = "Overall"
+        eval_features: dict[str, AuditorFeature] = {
+            "overall": AuditorFeature(name="overall", label="Overall")
+        }
+        eval_features.update(**self.features)
+
+        score_label = score.label if score.label is not None else score.name
+        error_eval = ErrorEvaluation(
+            name=score.name,
+            label=score_label,
+            threshold=threshold,
+        )
+
+        metric = RepresentationRatio()
+
+        for group_col in ("tp", "tn", "fp", "fn"):
+            group_eval = ScoreEvaluation(
+                name=group_col,
+                label=group_col.upper(),
+            )
+            for feature in eval_features.values():
+                feature_eval = self._evaluate_error_feature(
+                    data=data_slice,
+                    group_col=group_col,
+                    feature=feature,
+                    metric=metric,
+                    n_bootstraps=n_bootstraps,
+                )
+                group_eval.features[feature.name] = feature_eval
+            error_eval.groups[group_col] = group_eval
+
+        return error_eval
+
+    # ------------------------------------------------------------------ #
+    # Private evaluation helpers                                           #
+    # ------------------------------------------------------------------ #
 
     def _evaluate_feature(
         self, data: pd.DataFrame, feature: AuditorFeature, n_bootstraps: Optional[int]
@@ -436,6 +590,161 @@ class Auditor:
                             metric_label=metric.label,
                             metric_score=float("nan"),
                         )
+                    ordered_levels[cat_str] = placeholder
+            feature_eval.levels = ordered_levels
+
+        return feature_eval
+
+    def _evaluate_error_feature(
+        self,
+        data: pd.DataFrame,
+        group_col: str,
+        feature: AuditorFeature,
+        metric: AuditorErrorMetric,
+        n_bootstraps: Optional[int],
+    ) -> FeatureEvaluation:
+        """Compute error metrics for one feature within one confusion-matrix group.
+
+        Calculates the representation ratio for each feature level, then
+        optionally runs bootstrap resampling to derive confidence intervals and
+        replace the point estimate with the bootstrap mean.
+
+        Categorical dtype is honoured: declared-but-unobserved categories appear
+        as NaN placeholder rows (same behaviour as _evaluate_feature).
+
+        Args:
+            data: Full data slice including confusion indicator columns.
+            group_col: Column name of the confusion indicator ('tp', 'tn', etc.).
+            feature: The feature whose levels are being analysed.
+            metric: Error metric to compute (e.g. RepresentationRatio).
+            n_bootstraps: Bootstrap iterations, or None to skip.
+
+        Returns:
+            FeatureEvaluation with one LevelEvaluation per feature level.
+        """
+        feature_col = feature.name
+
+        is_categorical = isinstance(data[feature_col].dtype, pd.CategoricalDtype)
+        declared_categories: list[str] = []
+        if is_categorical:
+            declared_categories = [
+                str(c) for c in data[feature_col].cat.categories.tolist()
+            ]
+
+        # Drop rows where the feature is NaN; they don't belong to any level.
+        full_data = data.dropna(subset=[feature_col]).copy()
+        if not is_categorical:
+            full_data[feature_col] = full_data[feature_col].astype(str)
+
+        full_total = len(full_data)
+
+        # Per-level counts over the full dataset.
+        if is_categorical:
+            full_gs = full_data.groupby(feature_col, observed=True).size()
+        else:
+            full_gs = full_data.groupby(feature_col).size()
+        full_counts: dict[str, int] = {str(k): int(v) for k, v in full_gs.items()}
+
+        # Per-level counts within the confusion group.
+        group_data = full_data[full_data[group_col] == 1]
+        group_total = len(group_data)
+
+        if is_categorical:
+            group_gs = group_data.groupby(feature_col, observed=True).size() if not group_data.empty else pd.Series(dtype=int)
+        else:
+            group_gs = group_data.groupby(feature_col).size() if not group_data.empty else pd.Series(dtype=int)
+        group_counts: dict[str, int] = {str(k): int(v) for k, v in group_gs.items()}
+
+        # All levels to evaluate: declared order for categorical, observed order otherwise.
+        all_levels: list[str] = (
+            declared_categories if is_categorical else list(full_counts.keys())
+        )
+
+        feature_eval = FeatureEvaluation(
+            name=feature.name,
+            label=feature.label if feature.label is not None else feature.name,
+        )
+
+        # Point estimates (raw ratio, or bootstrap mean if bootstraps requested).
+        level_scores: dict[str, float] = {}
+        for level_name in all_levels:
+            full_count = full_counts.get(level_name, 0)
+            group_count = group_counts.get(level_name, 0)
+            level_scores[level_name] = metric.compute(
+                group_count=group_count,
+                group_total=group_total,
+                full_count=full_count,
+                full_total=full_total,
+            )
+
+        for level_name in all_levels:
+            feature_eval.update(
+                metric_name=metric.name,
+                metric_label=metric.label,
+                data={level_name: level_scores[level_name]},
+            )
+
+        # Bootstrap: replaces point estimates with bootstrap mean and adds CI.
+        # Levels with an undefined baseline (NaN score) are excluded — they cannot
+        # yield a meaningful CI and the NaN placeholder should be preserved.
+        if n_bootstraps is not None and metric.ci_eligible:
+            valid_levels = [l for l in all_levels if not np.isnan(level_scores[l])]
+
+            if valid_levels:
+                bootstrap_results: dict[str, NDArray[np.float64]] = {
+                    l: np.empty(n_bootstraps, dtype=np.float64) for l in valid_levels
+                }
+                n = len(data)  # resample from the full slice (all confusion groups)
+
+                for i in range(n_bootstraps):
+                    boot = data.sample(n, replace=True)
+                    boot_full = boot.dropna(subset=[feature_col]).copy()
+                    if not is_categorical:
+                        boot_full[feature_col] = boot_full[feature_col].astype(str)
+
+                    boot_full_total = len(boot_full)
+                    boot_group = boot_full[boot_full[group_col] == 1]
+                    boot_group_total = len(boot_group)
+
+                    if is_categorical:
+                        bfgs = boot_full.groupby(feature_col, observed=True).size()
+                        bgGs = boot_group.groupby(feature_col, observed=True).size() if not boot_group.empty else pd.Series(dtype=int)
+                    else:
+                        bfgs = boot_full.groupby(feature_col).size()
+                        bgGs = boot_group.groupby(feature_col).size() if not boot_group.empty else pd.Series(dtype=int)
+
+                    bfgs_dict: dict[str, int] = {str(k): int(v) for k, v in bfgs.items()}
+                    bgGs_dict: dict[str, int] = {str(k): int(v) for k, v in bgGs.items()}
+
+                    for level_name in valid_levels:
+                        bootstrap_results[level_name][i] = metric.compute(
+                            group_count=bgGs_dict.get(level_name, 0),
+                            group_total=boot_group_total,
+                            full_count=bfgs_dict.get(level_name, 0),
+                            full_total=boot_full_total,
+                        )
+
+                for level_name in valid_levels:
+                    bs = bootstrap_results[level_name]
+                    point_estimate = float(np.nanmean(bs))
+                    lower, upper = np.nanpercentile(bs, [2.5, 97.5])
+                    lm = feature_eval.levels[level_name].metrics[metric.name]
+                    lm.score = point_estimate
+                    lm.interval = (float(lower), float(upper))
+
+        # Categorical ordering and placeholders (mirrors _evaluate_feature).
+        if is_categorical:
+            ordered_levels: dict[str, LevelEvaluation] = {}
+            for cat_str in declared_categories:
+                if cat_str in feature_eval.levels:
+                    ordered_levels[cat_str] = feature_eval.levels[cat_str]
+                else:
+                    placeholder = LevelEvaluation(name=cat_str)
+                    placeholder.update(
+                        metric_name=metric.name,
+                        metric_label=metric.label,
+                        metric_score=float("nan"),
+                    )
                     ordered_levels[cat_str] = placeholder
             feature_eval.levels = ordered_levels
 

--- a/model_auditor/error_metrics.py
+++ b/model_auditor/error_metrics.py
@@ -1,0 +1,122 @@
+"""Error metrics for confusion-matrix group analysis.
+
+Defines the AuditorErrorMetric protocol and built-in implementations.
+Currently provides RepresentationRatio, which quantifies how over- or
+under-represented each feature level is within a given confusion-matrix group
+(TP, TN, FP, or FN) relative to its prevalence in the full dataset.
+
+Example::
+
+    from model_auditor.error_metrics import RepresentationRatio
+
+    # RepresentationRatio is the default metric used by Auditor.evaluate_errors().
+    # To implement a custom error metric, follow the AuditorErrorMetric protocol:
+
+    class MyErrorMetric:
+        name = "my_metric"
+        label = "My Metric"
+        ci_eligible = True
+
+        def compute(
+            self, group_count: int, group_total: int,
+            full_count: int, full_total: int
+        ) -> float:
+            ...
+"""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class AuditorErrorMetric(Protocol):
+    """Protocol for error metrics used in Auditor.evaluate_errors().
+
+    An error metric receives pre-aggregated counts from one confusion-matrix
+    group and the full dataset for a specific feature level, and returns a
+    scalar value representing some property of that group/level combination.
+
+    Attributes:
+        name: Unique identifier used as the dict key in result objects.
+        label: Human-readable display name.
+        ci_eligible: Whether bootstrap confidence intervals apply to this metric.
+    """
+
+    name: str
+    label: str
+    ci_eligible: bool
+
+    def compute(
+        self,
+        group_count: int,
+        group_total: int,
+        full_count: int,
+        full_total: int,
+    ) -> float:
+        """Compute the metric from pre-aggregated counts.
+
+        Args:
+            group_count: Rows in the confusion group that belong to this level.
+            group_total: Total rows in the confusion group.
+            full_count: Rows in the full dataset that belong to this level.
+            full_total: Total rows in the full dataset.
+
+        Returns:
+            Scalar metric value (may be NaN for undefined cases).
+        """
+        raise NotImplementedError
+
+
+class RepresentationRatio:
+    """Representation ratio: P(level | group) / P(level | full dataset).
+
+    Quantifies whether a feature level is over- or under-represented in a
+    confusion-matrix group relative to its prevalence in the full dataset.
+
+    Interpretation:
+        - 1.0: the level appears in the group at exactly its baseline rate.
+        - > 1.0: over-represented in the group (more common in errors / correct
+          predictions than in the data as a whole).
+        - < 1.0: under-represented.
+
+    Undefined cases:
+        - full_count == 0 (level absent from the full dataset): returns NaN.
+          This covers declared-but-unobserved categorical levels.
+        - group_total == 0 (empty confusion group): group rate is treated as
+          0.0, yielding ratio = 0.0 when full_count > 0.
+    """
+
+    name: str = "representation_ratio"
+    label: str = "Representation Ratio"
+    ci_eligible: bool = True
+
+    def compute(
+        self,
+        group_count: int,
+        group_total: int,
+        full_count: int,
+        full_total: int,
+    ) -> float:
+        """Compute the representation ratio.
+
+        Args:
+            group_count: Rows in the confusion group belonging to this level.
+            group_total: Total rows in the confusion group.
+            full_count: Rows in the full dataset belonging to this level.
+            full_total: Total rows in the full dataset.
+
+        Returns:
+            Representation ratio, or NaN if the level is absent from the
+            full dataset (full_count == 0 or full_total == 0).
+        """
+        # The baseline prevalence is undefined when the level has no rows in
+        # the full dataset; the ratio cannot be computed.
+        if full_total == 0 or full_count == 0:
+            return float("nan")
+
+        baseline = full_count / full_total
+
+        # When the confusion group is empty the level has zero representation
+        # in it, so the group rate is 0.
+        group_rate = group_count / group_total if group_total > 0 else 0.0
+
+        return group_rate / baseline

--- a/model_auditor/schemas.py
+++ b/model_auditor/schemas.py
@@ -593,3 +593,105 @@ class AuditorOutcome:
 
     name: str
     mapping: Optional[dict[Any, int]] = None
+
+
+
+@dataclass
+class ErrorEvaluation:
+    """Container for confusion-matrix group error analysis for a single score.
+
+    Groups evaluation results by confusion-matrix category (TP, TN, FP, FN),
+    each of which is itself a ScoreEvaluation holding per-feature representation
+    ratio metrics.
+
+    Attributes:
+        name: Name of the score that was evaluated.
+        label: Display label for the score.
+        threshold: Binarization threshold used during evaluation.
+        groups: Dictionary mapping group keys ('tp', 'tn', 'fp', 'fn') to
+            ScoreEvaluation objects containing per-feature metrics.
+    """
+
+    name: str
+    label: str
+    threshold: float
+    groups: dict[str, ScoreEvaluation] = field(default_factory=dict)
+
+    def to_dataframe(
+        self, n_decimals: int = 3, metric_labels: bool = False
+    ) -> pd.DataFrame:
+        """Convert error evaluation to a pandas DataFrame.
+
+        Returns a DataFrame with a three-level MultiIndex:
+        (group, feature, level), where group is one of TP/TN/FP/FN.
+
+        Args:
+            n_decimals: Number of decimal places for formatting scores.
+            metric_labels: If True, use metric labels as column names; else use names.
+
+        Returns:
+            DataFrame with MultiIndex (group, feature, level) and metrics as columns.
+        """
+        if not self.groups:
+            return pd.DataFrame()
+
+        frames: dict[str, pd.DataFrame] = {}
+        for group_name, group_eval in self.groups.items():
+            frames[group_name.upper()] = group_eval.to_dataframe(
+                n_decimals=n_decimals, metric_labels=metric_labels
+            )
+        return pd.concat(frames)
+
+    def style_dataframe(
+        self,
+        n_decimals: int = 3,
+        metric_labels: bool = False,
+        include_count_metrics: bool = False,
+        low_color: str = "#f8d7da",
+        medium_color: str = "#fff3cd",
+        high_color: str = "#d4edda",
+    ) -> pd.io.formats.style.Styler:
+        """Convert error evaluation to a styled pandas DataFrame for Jupyter display.
+
+        Styles cells based on relative representation ratio tiers across all
+        groups, features, and levels combined.
+
+        Args:
+            n_decimals: Number of decimal places for formatting scores.
+            metric_labels: If True, use metric labels as column names; else use names.
+            include_count_metrics: If True, include count metrics in tier styling.
+            low_color: Background color for low tier.
+            medium_color: Background color for medium tier.
+            high_color: Background color for high tier.
+
+        Returns:
+            A pandas Styler object with tier-based coloring applied.
+        """
+        display_df = self.to_dataframe(n_decimals=n_decimals, metric_labels=metric_labels)
+
+        numeric_data_list = []
+        metric_names: set[str] = set()
+
+        # Iterate in the same traversal order as to_dataframe() so that
+        # numeric_data_list rows align with display_df.index exactly.
+        for group_eval in self.groups.values():
+            for feature_eval in group_eval.features.values():
+                for level_eval in feature_eval.levels.values():
+                    level_numeric: dict[str, float] = {}
+                    for metric in level_eval.metrics.values():
+                        metric_key = metric.label if metric_labels else metric.name
+                        level_numeric[metric_key] = metric.score
+                        metric_names.add(metric_key)
+                    numeric_data_list.append(level_numeric)
+
+        numeric_df = pd.DataFrame(numeric_data_list, index=display_df.index)
+
+        return _apply_tier_styling(
+            display_df=display_df,
+            numeric_df=numeric_df,
+            metric_names=list(metric_names),
+            include_count_metrics=include_count_metrics,
+            low_color=low_color,
+            medium_color=medium_color,
+            high_color=high_color,
+        )

--- a/tests/test_error_evaluation.py
+++ b/tests/test_error_evaluation.py
@@ -1,0 +1,429 @@
+"""Tests for Auditor.evaluate_errors() and related result types.
+
+Coverage:
+- evaluate_errors() returns ErrorEvaluation with all four confusion groups.
+- RepresentationRatio formula correctness on deterministic synthetic data.
+- NaN baseline for levels absent from the full dataset (full_count == 0).
+- Zero-in-group: a level that appears in the full dataset but has no rows in a
+  specific confusion group yields ratio == 0.0 (not NaN).
+- Bootstrap mean replaces the raw ratio as point estimate when n_bootstraps > 0.
+- Bootstrap CI bounds are present and satisfy lower <= upper.
+- No CI for levels with NaN baseline, even when bootstraps are requested.
+- Categorical ordering is preserved across all groups.
+- to_dataframe() produces the expected MultiIndex structure.
+- Validation errors: missing data, missing outcome, bad score name, no threshold.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from model_auditor import Auditor
+from model_auditor.schemas import ErrorEvaluation, ScoreEvaluation
+
+
+# ---------------------------------------------------------------------------
+# Synthetic dataset
+# ---------------------------------------------------------------------------
+
+# Layout (threshold = 0.5):
+#   Female: 4 TP, 1 FP, 1 FN, 2 TN  → 8 rows
+#   Male:   3 TP, 1 FP, 1 FN, 3 TN  → 8 rows
+#   Other:  1 TP, 0 FP, 1 FN, 2 TN  → 4 rows
+#   Total:  8 TP, 2 FP, 3 FN, 7 TN  → 20 rows
+#
+# Representation ratios for Female in TP group:
+#   P(Female | full) = 8/20 = 0.4
+#   P(Female | TP)   = 4/8  = 0.5
+#   ratio            = 0.5 / 0.4 = 1.25
+#
+# Representation ratio for Other in FP group:
+#   P(Other | full) = 4/20  = 0.2
+#   P(Other | FP)   = 0/2   = 0.0
+#   ratio            = 0.0 / 0.2 = 0.0  (zero-in-group case)
+
+
+def _make_df(include_unknown: bool = False) -> pd.DataFrame:
+    """Return a deterministic binary-classification DataFrame.
+
+    Groups Female, Male, Other are always present.  If include_unknown=False,
+    'Unknown' is declared as a category but never observed, giving a
+    declared-but-unobserved level to test NaN baseline behaviour.
+    """
+    rows = []
+
+    # Female
+    rows.extend([{"gender": "Female", "score": 0.8, "label": 1}] * 4)  # TP
+    rows.append({"gender": "Female", "score": 0.7, "label": 0})          # FP
+    rows.append({"gender": "Female", "score": 0.3, "label": 1})          # FN
+    rows.extend([{"gender": "Female", "score": 0.2, "label": 0}] * 2)   # TN
+
+    # Male
+    rows.extend([{"gender": "Male", "score": 0.9, "label": 1}] * 3)     # TP
+    rows.append({"gender": "Male", "score": 0.6, "label": 0})            # FP
+    rows.append({"gender": "Male", "score": 0.4, "label": 1})            # FN
+    rows.extend([{"gender": "Male", "score": 0.1, "label": 0}] * 3)     # TN
+
+    # Other
+    rows.append({"gender": "Other", "score": 0.8, "label": 1})           # TP
+    rows.append({"gender": "Other", "score": 0.3, "label": 1})           # FN
+    rows.extend([{"gender": "Other", "score": 0.1, "label": 0}] * 2)    # TN
+
+    if include_unknown:
+        rows.extend([{"gender": "Unknown", "score": 0.8, "label": 1}] * 2)
+        rows.extend([{"gender": "Unknown", "score": 0.2, "label": 0}] * 2)
+
+    df = pd.DataFrame(rows)
+    categories = ["Female", "Male", "Other", "Unknown"]
+    df["gender"] = pd.Categorical(df["gender"], categories=categories, ordered=True)
+    return df
+
+
+def _make_auditor(df: pd.DataFrame) -> Auditor:
+    a = Auditor()
+    a.add_data(df)
+    a.add_feature(name="gender")
+    a.add_score(name="score", threshold=0.5)
+    a.add_outcome(name="label")
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Helpers for exact-ratio assertions
+# ---------------------------------------------------------------------------
+
+
+def _ratio(group_count: int, group_total: int, full_count: int, full_total: int) -> float:
+    if full_total == 0 or full_count == 0:
+        return float("nan")
+    baseline = full_count / full_total
+    group_rate = group_count / group_total if group_total > 0 else 0.0
+    return group_rate / baseline
+
+
+# ---------------------------------------------------------------------------
+# TestEvaluateErrorsStructure
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateErrorsStructure:
+    """evaluate_errors() returns the expected container structure."""
+
+    def test_returns_error_evaluation(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        assert isinstance(result, ErrorEvaluation)
+
+    def test_name_and_label(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        assert result.name == "score"
+        assert result.label == "score"
+
+    def test_threshold_stored(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        assert result.threshold == 0.5
+
+    def test_all_four_groups_present(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        assert set(result.groups.keys()) == {"tp", "tn", "fp", "fn"}
+
+    def test_each_group_is_score_evaluation(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        for group_eval in result.groups.values():
+            assert isinstance(group_eval, ScoreEvaluation)
+
+    def test_gender_feature_present_in_every_group(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        for group_eval in result.groups.values():
+            assert "gender" in group_eval.features
+
+    def test_overall_feature_present_in_every_group(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        for group_eval in result.groups.values():
+            assert "overall" in group_eval.features
+
+    def test_representation_ratio_metric_present_in_levels(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        gender = result.groups["tp"].features["gender"]
+        for level_eval in gender.levels.values():
+            assert "representation_ratio" in level_eval.metrics
+
+
+# ---------------------------------------------------------------------------
+# TestRepresentationRatioValues
+# ---------------------------------------------------------------------------
+
+
+class TestRepresentationRatioValues:
+    """Ratio formula correctness on deterministic data."""
+
+    def setup_method(self):
+        df = _make_df()
+        self.result = _make_auditor(df).evaluate_errors(score_name="score", n_bootstraps=None)
+
+    def _ratio_for(self, group: str, level: str) -> float:
+        return self.result.groups[group].features["gender"].levels[level].metrics["representation_ratio"].score
+
+    def test_female_in_tp(self):
+        # P(Female|full)=8/20=0.4, P(Female|TP)=4/8=0.5 → 1.25
+        expected = _ratio(4, 8, 8, 20)
+        assert abs(self._ratio_for("tp", "Female") - expected) < 1e-10
+
+    def test_male_in_tp(self):
+        # P(Male|full)=8/20=0.4, P(Male|TP)=3/8=0.375 → 0.9375
+        expected = _ratio(3, 8, 8, 20)
+        assert abs(self._ratio_for("tp", "Male") - expected) < 1e-10
+
+    def test_other_in_tp(self):
+        # P(Other|full)=4/20=0.2, P(Other|TP)=1/8=0.125 → 0.625
+        expected = _ratio(1, 8, 4, 20)
+        assert abs(self._ratio_for("tp", "Other") - expected) < 1e-10
+
+    def test_female_in_fn(self):
+        # FN total = 3; Female FN = 1
+        expected = _ratio(1, 3, 8, 20)
+        assert abs(self._ratio_for("fn", "Female") - expected) < 1e-10
+
+    def test_overall_ratio_is_one_for_nonempty_group(self):
+        # P(Overall|group) / P(Overall|full) = 1.0 by definition when group non-empty.
+        for group in ("tp", "tn", "fp", "fn"):
+            overall_ratio = (
+                self.result.groups[group]
+                .features["overall"]
+                .levels["Overall"]
+                .metrics["representation_ratio"]
+                .score
+            )
+            assert abs(overall_ratio - 1.0) < 1e-10, (
+                f"Overall ratio for group '{group}' should be 1.0, got {overall_ratio}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestZeroInGroup
+# ---------------------------------------------------------------------------
+
+
+class TestZeroInGroup:
+    """Level present in full dataset but absent from a confusion group → ratio 0.0."""
+
+    def test_other_in_fp_is_zero(self):
+        # Other has no FP rows (score threshold 0.5; all Other scores are 0.3/0.1).
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        fp_other = result.groups["fp"].features["gender"].levels["Other"]
+        ratio = fp_other.metrics["representation_ratio"].score
+        assert ratio == 0.0, f"Expected 0.0 for Other in FP, got {ratio}"
+
+    def test_zero_ratio_is_not_nan(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        ratio = (
+            result.groups["fp"].features["gender"].levels["Other"]
+            .metrics["representation_ratio"].score
+        )
+        assert not math.isnan(ratio), "Zero-in-group ratio must not be NaN"
+
+
+# ---------------------------------------------------------------------------
+# TestNaNBaseline
+# ---------------------------------------------------------------------------
+
+
+class TestNaNBaseline:
+    """Level absent from the full dataset (full_count == 0) → ratio NaN, no CI."""
+
+    def test_unobserved_category_nan_ratio(self):
+        # 'Unknown' is a declared category with zero rows in the full dataset.
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        unknown = result.groups["tp"].features["gender"].levels["Unknown"]
+        ratio = unknown.metrics["representation_ratio"].score
+        assert math.isnan(ratio), f"Expected NaN for unobserved 'Unknown', got {ratio}"
+
+    def test_unobserved_category_no_ci(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=500)
+        for group in ("tp", "tn", "fp", "fn"):
+            unknown = result.groups[group].features["gender"].levels["Unknown"]
+            lm = unknown.metrics["representation_ratio"]
+            assert lm.interval is None, (
+                f"NaN-baseline level 'Unknown' in group '{group}' must have no CI, "
+                f"got {lm.interval}"
+            )
+
+    def test_unobserved_category_nan_score_with_bootstraps(self):
+        """Bootstrap must preserve NaN score for levels with undefined baseline."""
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=50)
+        unknown = result.groups["tp"].features["gender"].levels["Unknown"]
+        assert math.isnan(unknown.metrics["representation_ratio"].score)
+
+
+# ---------------------------------------------------------------------------
+# TestBootstrap
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrap:
+    """Bootstrap path: point estimate becomes bootstrap mean; CI bounds populated."""
+
+    def test_observed_levels_have_ci(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=100)
+        for level in ("Female", "Male", "Other"):
+            lm = result.groups["tp"].features["gender"].levels[level].metrics["representation_ratio"]
+            assert lm.interval is not None, (
+                f"Observed level '{level}' must have a CI after bootstrapping"
+            )
+
+    def test_ci_lower_le_upper(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=100)
+        for group in ("tp", "tn", "fp", "fn"):
+            for level in ("Female", "Male", "Other"):
+                lm = (
+                    result.groups[group]
+                    .features["gender"]
+                    .levels[level]
+                    .metrics["representation_ratio"]
+                )
+                if lm.interval is not None:
+                    lower, upper = lm.interval
+                    assert lower <= upper, (
+                        f"CI for {level} in {group}: lower={lower} > upper={upper}"
+                    )
+
+    def test_bootstrap_mean_is_float(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=50)
+        lm = result.groups["tp"].features["gender"].levels["Female"].metrics["representation_ratio"]
+        assert isinstance(lm.score, float)
+
+    def test_no_bootstraps_no_ci(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        for group in ("tp", "tn", "fp", "fn"):
+            for level in ("Female", "Male", "Other"):
+                lm = (
+                    result.groups[group]
+                    .features["gender"]
+                    .levels[level]
+                    .metrics["representation_ratio"]
+                )
+                assert lm.interval is None, (
+                    f"No bootstraps requested; {level} in {group} should have no CI"
+                )
+
+
+# ---------------------------------------------------------------------------
+# TestCategoricalOrdering
+# ---------------------------------------------------------------------------
+
+
+DECLARED_ORDER = ["Female", "Male", "Other", "Unknown"]
+
+
+class TestCategoricalOrdering:
+    """Declared categorical order is preserved in every group's feature evaluation."""
+
+    def test_gender_levels_follow_declared_order_in_all_groups(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        for group_name, group_eval in result.groups.items():
+            keys = list(group_eval.features["gender"].levels.keys())
+            assert keys == DECLARED_ORDER, (
+                f"Group '{group_name}': expected {DECLARED_ORDER}, got {keys}"
+            )
+
+    def test_unobserved_unknown_present_in_all_groups(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        for group_name, group_eval in result.groups.items():
+            assert "Unknown" in group_eval.features["gender"].levels, (
+                f"'Unknown' placeholder missing from group '{group_name}'"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestToDataframe
+# ---------------------------------------------------------------------------
+
+
+class TestToDataframe:
+    """ErrorEvaluation.to_dataframe() structure and content."""
+
+    def test_returns_dataframe(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        df = result.to_dataframe()
+        assert isinstance(df, pd.DataFrame)
+
+    def test_multiindex_has_three_levels(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        df = result.to_dataframe()
+        assert df.index.nlevels == 3, (
+            f"Expected 3-level MultiIndex (group, feature, level), got {df.index.nlevels}"
+        )
+
+    def test_all_four_groups_in_top_index_level(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        df = result.to_dataframe()
+        top_level_groups = set(df.index.get_level_values(0).unique())
+        assert top_level_groups == {"TP", "TN", "FP", "FN"}
+
+    def test_representation_ratio_column_present(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        df = result.to_dataframe()
+        assert "representation_ratio" in df.columns
+
+    def test_metric_labels_flag(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        df = result.to_dataframe(metric_labels=True)
+        assert "Representation Ratio" in df.columns
+
+    def test_n_decimals_applied(self):
+        result = _make_auditor(_make_df()).evaluate_errors(score_name="score", n_bootstraps=None)
+        df2 = result.to_dataframe(n_decimals=2)
+        df5 = result.to_dataframe(n_decimals=5)
+        # Different precision → different string representations for non-NaN values
+        assert df2["representation_ratio"].iloc[0] != df5["representation_ratio"].iloc[0]
+
+    def test_empty_groups_dict_returns_empty_dataframe(self):
+        from model_auditor.schemas import ErrorEvaluation
+        empty = ErrorEvaluation(name="x", label="x", threshold=0.5)
+        df = empty.to_dataframe()
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestValidation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    """evaluate_errors() raises descriptive errors for invalid state."""
+
+    def test_no_data_raises(self):
+        a = Auditor()
+        a.add_score(name="score", threshold=0.5)
+        with pytest.raises(ValueError, match="add_data"):
+            a.evaluate_errors(score_name="score")
+
+    def test_no_outcome_raises(self):
+        a = Auditor()
+        a.add_data(pd.DataFrame({"score": [0.5], "label": [1]}))
+        a.add_score(name="score", threshold=0.5)
+        with pytest.raises(ValueError, match="add_outcome"):
+            a.evaluate_errors(score_name="score")
+
+    def test_unknown_score_name_raises(self):
+        a = _make_auditor(_make_df())
+        with pytest.raises(ValueError, match="not found"):
+            a.evaluate_errors(score_name="nonexistent")
+
+    def test_no_threshold_raises(self):
+        a = Auditor()
+        df = _make_df()
+        a.add_data(df)
+        a.add_feature(name="gender")
+        a.add_score(name="score")  # no threshold
+        a.add_outcome(name="label")
+        with pytest.raises(ValueError, match="[Tt]hreshold"):
+            a.evaluate_errors(score_name="score")
+
+    def test_threshold_passed_at_call_time(self):
+        """Threshold can be overridden per-call even when one is set on the score."""
+        a = _make_auditor(_make_df())
+        result = a.evaluate_errors(score_name="score", threshold=0.6, n_bootstraps=None)
+        assert result.threshold == 0.6

--- a/tests/test_feature_level_ordering.py
+++ b/tests/test_feature_level_ordering.py
@@ -61,9 +61,7 @@ def _make_auditor(df: pd.DataFrame, metrics=None) -> Auditor:
 
 def _evaluate(include_d: bool = False, n_bootstraps=None, metrics=None):
     df = _make_df(include_d=include_d)
-    return _make_auditor(df, metrics=metrics).evaluate(
-        score_name="score", n_bootstraps=n_bootstraps
-    )
+    return _make_auditor(df, metrics=metrics).evaluate_metrics(score_name="score", n_bootstraps=n_bootstraps)
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +259,7 @@ class TestNonCategoricalPreservation:
         df = _make_df()
         # Strip categorical dtype → plain object/string column
         df["group"] = df["group"].astype(str)
-        return _make_auditor(df).evaluate(score_name="score", n_bootstraps=None)
+        return _make_auditor(df).evaluate_metrics(score_name="score", n_bootstraps=None)
 
     def test_non_categorical_evaluates_without_error(self):
         """String-typed feature evaluates successfully."""


### PR DESCRIPTION
- Implemented `evaluate_errors()` method for analyzing representation within confusion matrix groups.
- Introduced `RepresentationRatio` metric measuring level over/under-representation in error groups.
- Added `ErrorEvaluation` schema for structuring error analysis results hierarchically.
- Implemented feature level ordering in results using pandas Categorical dtype.
- Added 429 lines of test coverage for error evaluation and representation ratio edge cases.